### PR TITLE
fix error of non-found smach_tutorials.msg

### DIFF
--- a/examples/actionlib2_test.py
+++ b/examples/actionlib2_test.py
@@ -4,7 +4,7 @@ import rospy
 import smach
 import smach_ros
 
-from smach_tutorials.msg import TestAction, TestGoal
+from actionlib.msg import TestAction, TestGoal
 from actionlib import *
 from actionlib_msgs.msg import *
 

--- a/examples/actionlib_test.py
+++ b/examples/actionlib_test.py
@@ -22,7 +22,7 @@ import rospy
 import smach
 import smach_ros
 
-from smach_tutorials.msg import TestAction, TestGoal
+from actionlib.msg import TestAction, TestGoal
 from actionlib import *
 from actionlib_msgs.msg import *
 


### PR DESCRIPTION
import smach_tutorials.msg would cause an error. A quick fix applied to eliminate this error.