### PR TITLE
package.xml need message_generation for compile

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>message_generation</build_depend>
+
   <run_depend>rospy</run_depend>
   <run_depend>smach</run_depend>
   <run_depend>smach_ros</run_depend>


### PR DESCRIPTION
I can not compile this package on kinetic without this patch, fyi @rhaschke 
```
---------------------------------------------------------------------
Workspace configuration appears valid.
---------------------------------------------------------------------
[build] Found '3' packages in 0.0 seconds.                                                         
[build] Updating package table.                                                                    
Starting  >>> smach_tutorials                                                                      
Starting  >>> smach_viewer                                                                         
Finished  <<< smach_viewer                   [ 1.4 seconds ]                                       
k[build [build - 4.2] [1/2 complete] [1/8 jobs] [0 queued] [smach_tutorials:make (77%) - 4.2]       ___________________________________________________________________________________________________ 
Errors     << smach_tutorials:make /home/k-okada/catkin_ws/ws_smach/logs/smach_tutorials/build.make.000.log
Traceback (most recent call last):
  File "/opt/ros/kinetic/share/genjava/cmake/../../../lib/genjava/genjava_gradle_project.py", line 14, in <module>
    genjava.main(sys.argv)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/genjava/genjava_main.py", line 82, in main
    gradle_project.create(args.package, args.output_dir)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/genjava/gradle_project.py", line 149, in create
    os.makedirs(genjava_gradle_dir)
  File "/usr/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/home/k-okada/catkin_ws/ws_smach/build/smach_tutorials/java/smach_tutorials'
make[2]: *** [java/smach_tutorials/build.gradle] Error 1
make[1]: *** [CMakeFiles/smach_tutorials_generate_messages_java_gradle.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
Traceback (most recent call last):
  File "/opt/ros/kinetic/share/genjava/cmake/../../../lib/genjava/genjava_gradle_project.py", line 14, in <module>
    genjava.main(sys.argv)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/genjava/genjava_main.py", line 82, in main
    gradle_project.create(args.package, args.output_dir)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/genjava/gradle_project.py", line 152, in create
    raise IOError("could not find %s among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?" % msg_pkg_name)
IOError: could not find smach_tutorials among message packages. Does the that package have a <build_depend> on message_generation in its package.xml?
make[2]: *** [java/smach_tutorials/build.gradle] Error 1
make[1]: *** [CMakeFiles/smach_tutorials_generate_messages_java.dir/all] Error 2
```